### PR TITLE
DO NOT MERGE: Use GitHub connector by default

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -92,7 +92,7 @@ func GetCert(_ context.Context, sv signature.SignerVerifier, idToken, flow, oidc
 	case flowDevice:
 		c.flow = oauthflow.NewDeviceFlowTokenGetterForIssuer(oidcIssuer)
 	case flowNormal:
-		c.flow = oauthflow.DefaultIDTokenGetter
+		c.flow = oauthflow.PublicInstanceGithubIDTokenGetter // oauthflow.DefaultIDTokenGetter
 	case flowToken:
 		c.flow = &oauthflow.StaticTokenGetter{RawToken: idToken}
 	default:


### PR DESCRIPTION
To do this properly, we'd want to expose a new CLI flag.